### PR TITLE
Use kill instead of interrupt to stop etcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .idea
 *.coverprofile
+*.exe

--- a/cmd/rep/main_suite_test.go
+++ b/cmd/rep/main_suite_test.go
@@ -44,7 +44,7 @@ var _ = BeforeEach(func() {
 
 var _ = SynchronizedAfterSuite(func() {
 	if etcdRunner != nil {
-		etcdRunner.Stop()
+		etcdRunner.KillWithFire()
 	}
 	if runner != nil {
 		runner.KillWithFire()

--- a/generator/internal/internal_suite_test.go
+++ b/generator/internal/internal_suite_test.go
@@ -28,5 +28,5 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	etcdClient.Disconnect()
-	etcdRunner.Stop()
+	etcdRunner.KillWithFire()
 })


### PR DESCRIPTION
Interrupting a process doesn't work on windows, but kill seems to be
doing the job. Since this is a cleanup step after all tests have run,
kill and interrupt should be equivalent.