### PR TITLE
Fixes more tests on Windows

### DIFF
--- a/cmd/rep/main_suite_test.go
+++ b/cmd/rep/main_suite_test.go
@@ -127,7 +127,7 @@ var _ = SynchronizedAfterSuite(func() {
 		etcdRunner.KillWithFire()
 	}
 	if consulRunner != nil {
-		consulRunner.Stop()
+		consulRunner.KillWithFire()
 	}
 	if runner != nil {
 		runner.KillWithFire()

--- a/generator/internal/internal_suite_test.go
+++ b/generator/internal/internal_suite_test.go
@@ -63,7 +63,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = SynchronizedAfterSuite(func() {
-	consulRunner.Stop()
+	consulRunner.KillWithFire()
 	etcdRunner.KillWithFire()
 }, func() {
 	gexec.CleanupBuildArtifacts()


### PR DESCRIPTION
Another fix for us running the rep test suite on Windows. `consulRunner.Stop` will try to use Interrupt, which doesn't work on Windows.

https://github.com/cloudfoundry-incubator/consuladapter/commit/581f4f7caa186a4f0185eebef01b7065b06177be

https://www.pivotaltracker.com/story/show/104201496