### PR TITLE
Fix test race in maintain and harmonizer pkg

### DIFF
--- a/harmonizer/bulker_test.go
+++ b/harmonizer/bulker_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Bulker", func() {
 
 	JustBeforeEach(func() {
 		process = ifrit.Invoke(bulker)
+		Eventually(fakeClock.WatcherCount).Should(Equal(1))
 	})
 
 	AfterEach(func() {

--- a/maintain/maintain_test.go
+++ b/maintain/maintain_test.go
@@ -191,6 +191,7 @@ var _ = Describe("Maintain Presence", func() {
 				BeforeEach(func() {
 					pingErrors <- errors.New("failed to ping")
 					clock.Increment(1 * time.Second)
+					Eventually(fakeClient.PingCallCount).Should(Equal(3))
 				})
 
 				It("stops heartbeating the executor's presence", func() {
@@ -198,7 +199,7 @@ var _ = Describe("Maintain Presence", func() {
 				})
 
 				It("continues pinging the executor", func() {
-					for i := 2; i < 6; i++ {
+					for i := 4; i < 8; i++ {
 						pingErrors <- errors.New("failed again")
 						clock.Increment(1 * time.Second)
 						Eventually(fakeClient.PingCallCount).Should(Equal(i))
@@ -208,7 +209,7 @@ var _ = Describe("Maintain Presence", func() {
 				Context("when the executor ping succeeds again", func() {
 					BeforeEach(func() {
 						pingErrors <- nil
-						Eventually(fakeClient.PingCallCount).Should(Equal(3))
+						Eventually(fakeHeartbeater.RunCallCount, 10*config.RetryInterval).Should(Equal(2))
 						pingErrors <- nil
 						clock.Increment(1 * time.Second)
 						Eventually(fakeClient.PingCallCount).Should(Equal(4))
@@ -219,7 +220,7 @@ var _ = Describe("Maintain Presence", func() {
 					})
 
 					It("continues to ping the executor", func() {
-						for i := 4; i < 6; i++ {
+						for i := 5; i < 7; i++ {
 							pingErrors <- nil
 							clock.Increment(1 * time.Second)
 							Eventually(fakeClient.PingCallCount).Should(Equal(i))


### PR DESCRIPTION
There seems to be sync issues with the fake clock in some tests. I had to debug them previously to make sure they are not windows related. I saw that @mhoran also experienced this issue so I am making a PR out of this fix.
This flaky errors seams to also appear on on linux + go1.5.1.

Errors:

* 1
```
------------------------------
• Failure [1.016 seconds]
Maintain Presence
C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:265
  when pinging the executor succeeds
  C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:264
    when the heartbeater is ready
    C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:263
      when the executor ping fails
      C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:229
        continues pinging the executor [It]
        C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:206

        Timed out after 1.000s.
        Expected
            <int>: 4
        to equal
            <int>: 2

        C:/Users/stefans/gowp/src/github.com/cloudfoundry-incubator/rep/maintain/maintain_test.go:204
```

* 2
```
[1447754814] Harmonizer Suite - 15/15 specs •••{"timestamp":"1447754891.556613207","source":"test","message":"test.running-bulker.starting","log_level":1,"data":{"interval":"30s","session":"1"}}
{"timestamp":"1447754892.561636686","source":"test","message":"test.running-bulker.received-signal","log_level":1,"data":{"session":"1","signal":"interrupt"}}
{"timestamp":"1447754892.561676979","source":"test","message":"test.running-bulker.finished","log_level":1,"data":{"session":"1"}}

------------------------------
• Failure [1.016 seconds]
Bulker when the poll interval elapses and elapses again when generating the batch operations succeeds [It] pushes them onto the queue 
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:91

  Timed out after 1.002s.
  Expected
      <int>: 0
  to equal
      <int>: 2

  /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:84
------------------------------
•••••••••••

Summarizing 1 Failure:

[Fail] Bulker when the poll interval elapses and elapses again when generating the batch operations succeeds [It] pushes them onto the queue 
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:84

Ran 15 of 15 Specs in 1.586 seconds
FAIL! -- 14 Passed | 1 Failed | 0 Pending | 0 Skipped --- FAIL: TestHarmonizer (1.59s)
FAIL
```

* 3
```
[1447755018] Harmonizer Suite - 3/15 specs SSSSSS••{"timestamp":"1447755094.677377462","source":"test","message":"test.running-bulker.starting","log_level":1,"data":{"interval":"30s","session":"1"}}
{"timestamp":"1447755095.680546761","source":"test","message":"test.running-bulker.received-signal","log_level":1,"data":{"session":"1","signal":"interrupt"}}
{"timestamp":"1447755095.680604696","source":"test","message":"test.running-bulker.finished","log_level":1,"data":{"session":"1"}}

------------------------------
• Failure [1.014 seconds]
Bulker when the poll interval elapses and elapses again when generating the batch operations fails [It] logs the error 
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:112

  Timed out after 1.000s.
  Got stuck at:
      {"timestamp":"1447755094.677377462","source":"test","message":"test.running-bulker.starting","log_level":1,"data":{"interval":"30s","session":"1"}}
      
  Waiting for:
      failed-to-generate-operations

  /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:110
------------------------------
SSSSSS

Summarizing 1 Failure:

[Fail] Bulker when the poll interval elapses and elapses again when generating the batch operations fails [It] logs the error 
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:110

Ran 3 of 15 Specs in 1.059 seconds
FAIL! -- 2 Passed | 1 Failed | 0 Pending | 12 Skipped --- FAIL: TestHarmonizer (1.06s)
FAIL

Ginkgo ran 9 suites in 1m16.788608919s
Test Suite Failed
```

Related to this story: https://www.pivotaltracker.com/story/show/104201496


There is also another issue that only manifested on linux (for witch I don't know how to make fix without some refactoring):

* Related but not fixed:

```
Running Suite: Harmonizer Suite
===============================
Random Seed: 1447755972
Will run 15 of 15 specs

••••••••••••••{"timestamp":"1447755972.968476534","source":"test","message":"test.running-bulker.starting","log_level":1,"data":{"interval":"30s","session":"1"}}
{"timestamp":"1447755972.968564987","source":"test","message":"test.running-bulker.notified-of-evacuation","log_level":1,"data":{"session":"1"}}
{"timestamp":"1447755972.968600988","source":"test","message":"test.running-bulker.sync.starting","log_level":1,"data":{"session":"1.1"}}
{"timestamp":"1447755972.968631506","source":"test","message":"test.running-bulker.sync.finished","log_level":1,"data":{"session":"1.1"}}
{"timestamp":"1447755973.972876549","source":"test","message":"test.running-bulker.received-signal","log_level":1,"data":{"session":"1","signal":"interrupt"}}
{"timestamp":"1447755973.972918510","source":"test","message":"test.running-bulker.finished","log_level":1,"data":{"session":"1"}}

------------------------------
• Failure [1.016 seconds]
Bulker
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:163
  when evacuation starts
  /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:162
    when the evacuation interval elapses
    /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:161
      batches operations again [It]
      /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:160

      Timed out after 1.001s.
      Expected
          <int>: 1
      to equal
          <int>: 2

      /home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:158
------------------------------


Summarizing 1 Failure:

[Fail] Bulker when evacuation starts when the evacuation interval elapses [It] batches operations again 
/home/stefans/.gvm/pkgsets/go1.5.1/global/src/github.com/cloudfoundry-incubator/rep/harmonizer/bulker_test.go:158

Ran 15 of 15 Specs in 1.470 seconds
FAIL! -- 14 Passed | 1 Failed | 0 Pending | 0 Skipped --- FAIL: TestHarmonizer (1.47s)
FAIL

Tests failed on attempt #10


Ginkgo ran 1 suite in 10.119599231s
Test Suite Failed

```
Summary of the last issue:
[timer.Reset(interval)](https://github.com/cloudfoundry-incubator/rep/blob/master/harmonizer/bulker.go#L82) must be invoked after [fakeClock.Increment](https://github.com/cloudfoundry-incubator/rep/blob/master/harmonizer/bulker_test.go#L156)